### PR TITLE
line breaks in startproc scripts

### DIFF
--- a/bashbot.sh
+++ b/bashbot.sh
@@ -65,6 +65,7 @@ send_message() {
 	local text="$(echo "$2" | sed 's/ mykeyboardstartshere.*//g;s/ myfilelocationstartshere.*//g;s/ mylatstartshere.*//g;s/ mylongstartshere.*//g;s/ mytitlestartshere.*//g;s/ myaddressstartshere.*//g;s/ mykeyboardendshere.*//g')"
 	local arg="$3"
 	[ "$3" != "safe" ] && {
+		text="$(echo "$text" | sed 's/ mynewlinestartshere /\r\n/g')" # hack for linebreaks in startproc scripts
 		local no_keyboard="$(echo $2 | sed '/mykeyboardendshere/!d;s/.*mykeyboardendshere.*/mykeyboardendshere/')"
 
 		local keyboard="$(echo "$2" | sed '/mykeyboardstartshere /!d;s/.*mykeyboardstartshere //g;s/ myfilelocationstartshere.*//g;s/ mylatstartshere.*//g;s/ mylongstartshere.*//g;s/ mytitlestartshere.*//g;s/ myaddressstartshere.*//g;s/ mykeyboardendshere.*//g')"


### PR DESCRIPTION
Hi again,

if you call send_text with a string containing line breaks (\r\n)  the text is displayed in one telegram message including line breaks. If you do the same from a script started by startproc, the text is displayed as seperate messages if it contains line breaks. this is because 'read' stops reading at line breaks and so the message is split.

to work around this I implemented the keyword 'mynewlinestartshere' as a placeholder for line breaks, similiar to mykeaybordstartshere etc. may be you find it useful