### PR TITLE
extend start/killproc to allow multiple background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Allowed values: typing for text messages, upload_photo for photos, record_video 
 send_action "${CHAT[ID]}" "action"
 ```
 
+#### Interactice Chats and background jobs
 To create interactive chats, write (or edit the question script) a normal bash (or C or python) script, chmod +x it and then change the argument of the startproc function to match the command you usually use to start the script.
 The text that the script will output will be sent in real time to the user, and all user input will be sent to the script (as long as it's running or until the user kills it with /cancel).
 To open up a keyboard in an interactive script, print out the keyboard layout in the following way:
@@ -178,6 +179,20 @@ echo "Text that will appear in chat? mykeyboardstartshere \"Yep, sure\" \"No, hi
 ```
 Please note that you can either send a location or a venue, not both. To send a venue add the mytitlestartshere and the myaddressstartshere keywords.
 
+A background job is similar to an interactive chat, but runs in the background and does only output massages instead of processing input from the user. In contrast to interactive chats it's possible to run multiple background jobs. To create a background job write a script or edit the notify script and use the funtion background to start it:
+```
+background "./notify" "jobname"
+```
+All output of the script will be sent to the user or chat. To stop a background job use:
+```
+stopback "jobname"
+```
+You can restart the last running background jobs, e.g. after a reboot, with the command:
+```
+./bashbot.sh background
+```
+
+#### Inline queries
 The following commands allows users to interact with your bot via *inline queries*.
 In order to enable **inline mode**, send `/setinline` command to [@BotFather](https://telegram.me/botfather) and provide the placeholder text that the user will see in the input field after typing your bot’s name.
 Also, edit line 12 from `commands.sh` putting a "1".

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ background "./notify" "jobname"
 ```
 All output of the script will be sent to the user or chat. To stop a background job use:
 ```
-stopback "jobname"
+killback "jobname"
 ```
 You can restart the last running background jobs, e.g. after a reboot, with the command:
 ```

--- a/bashbot.sh
+++ b/bashbot.sh
@@ -512,7 +512,6 @@ case "$1" in
 			echo -e "\e[0;31mNo background processes.\e[0m"; break
 		    else
 			REMOVE="$(cat "$FILE")"
-			CHAT[ID]="${REMOVE%%:*}"
 			JOB="${REMOVE#*:}"
 			fifo="back-${JOB%:*}-${ME}_${REMOVE%%:*}"
 			echo "killbackground  ${fifo}"

--- a/bashbot.sh
+++ b/bashbot.sh
@@ -10,6 +10,8 @@
 # This file is public domain in the USA and all free countries.
 # Elsewhere, consider it to be WTFPLv2. (wtfpl.net/txt/copying)
 
+TMPDIR="./tmp-bot-bash"
+
 if [ ! -f "JSON.sh/JSON.sh" ]; then
 	echo "You did not clone recursively! Downloading JSON.sh..."
 	git clone http://github.com/dominictarr/JSON.sh
@@ -22,6 +24,10 @@ if [ ! -f "token" ]; then
 	echo "PLEASE WRITE YOUR TOKEN HERE"
 	read token
 	echo "$token" >> token
+fi
+
+if [ ! -d "$TMPDIR" ]; then
+	mkdir "$TMPDIR"
 fi
 
 source commands.sh source
@@ -45,6 +51,7 @@ ACTION_URL=$URL'/sendChatAction'
 FORWARD_URL=$URL'/forwardMessage'
 INLINE_QUERY=$URL'/answerInlineQuery'
 ME_URL=$URL'/getMe'
+DELETE_URL=$URL'/deleteMessage'
 ME=$(curl -s $ME_URL | ./JSON.sh/JSON.sh -s | egrep '\["result","username"\]' | cut -f 2 | cut -d '"' -f 2)
 
 
@@ -81,7 +88,7 @@ send_message() {
 
 	}
 	if [ "$no_keyboard" != "" ]; then
-		echo "remove_keyboard $chat $text" > /tmp/prova
+		echo "remove_keyboard $chat $text" > $TMPDIR/prova
 		remove_keyboard "$chat" "$text"
 		local sent=y
 	fi
@@ -321,15 +328,37 @@ forward() {
 	res=$(curl -s "$FORWARD_URL" -F "chat_id=$1" -F "from_chat_id=$2" -F "message_id=$3")
 }
 
+
+background() {
+	echo "${CHAT[ID]}:$2:$1" >"$TMPDIR/${copname}$2-back.cmd"
+	startproc "$1" "back-$2-"
+}
+
 startproc() {
-	killproc
-	mkfifo /tmp/$copname
-	TMUX= tmux new-session -d -s $copname "$* &>/tmp/$copname; echo imprettydarnsuredatdisisdaendofdacmd>/tmp/$copname"
-	TMUX= tmux new-session -d -s sendprocess_$copname "bash $SCRIPT outproc ${CHAT[ID]} $copname"
+	killproc "$2"
+	local fifo="$2${copname}" # add $1 to copname, so we can have more than one running script per chat
+	mkfifo "$TMPDIR/${fifo}"
+	TMUX= tmux new-session -d -s "${fifo}" "$1 &>$TMPDIR/${fifo}; echo imprettydarnsuredatdisisdaendofdacmd>$TMPDIR/${fifo}"
+	TMUX= tmux new-session -d -s sendprocess_${fifo} "bash $SCRIPT outproc ${CHAT[ID]} ${fifo}"
+}
+
+
+checkback() {
+	checkproc "back-$1-"
+}
+
+checkproc() {
+	tmux ls | grep -q "$1${copname}"; res=$?
+}
+
+killback() {
+	killproc "back-$1-"
+	rm "$TMPDIR/${copname}$1-back.cmd"
 }
 
 killproc() {
-	(tmux kill-session -t $copname; echo imprettydarnsuredatdisisdaendofdacmd>/tmp/$copname; tmux kill-session -t sendprocess_$copname; rm -r /tmp/$copname)2>/dev/null
+	local fifo="$1${copname}"
+	(tmux kill-session -t "${fifo}"; echo imprettydarnsuredatdisisdaendofdacmd>$TMPDIR/${fifo}; tmux kill-session -t sendprocess_${fifo}; rm -r $TMPDIR/${fifo})2>/dev/null
 }
 
 inproc() {
@@ -429,8 +458,8 @@ case "$1" in
 			line=
 			read -t 10 line
 			[ "$line" != "" -a "$line" != "imprettydarnsuredatdisisdaendofdacmd" ] && send_message "$2" "$line"
-		done </tmp/$3
-		rm -r /tmp/$3
+		done <$TMPDIR/$3
+		rm -r $TMPDIR/$3
 		;;
 	"count")
 		echo "A total of $(wc -l count | sed 's/count//g')users used me."

--- a/bashbot.sh
+++ b/bashbot.sh
@@ -504,6 +504,23 @@ case "$1" in
 		send_markdown_message "${CHAT[ID]}" "*Bot stopped*"
 		echo -e '\e[0;32mOK. Bot stopped successfully.\e[0m'
 		;;
+	"killback")
+		clear
+		echo -e "\e[0;32mRemove background processes ...\e[0m"
+		for FILE in ${TMPDIR}/*-back.cmd; do
+		    if [ "$FILE" == "${TMPDIR}/*-back.cmd" ]; then
+			echo -e "\e[0;31mNo background processes.\e[0m"; break
+		    else
+			REMOVE="$(cat "$FILE")"
+			CHAT[ID]="${REMOVE%%:*}"
+			JOB="${REMOVE#*:}"
+			fifo="back-${JOB%:*}-${ME}_${REMOVE%%:*}"
+			echo "killbackground  ${fifo}"
+			rm $FILE
+			( tmux kill-session -t "${fifo}"; tmux kill-session -t sendprocess_${fifo}; rm -r $TMPDIR/${fifo}) 2>/dev/null
+		    fi
+		done
+		;;
 	"help")
 		clear
 		less README.md
@@ -516,7 +533,7 @@ case "$1" in
 		;;
 	*)
 		echo -e '\e[0;31mBAD REQUEST\e[0m'
-		echo -e '\e[0;31mAvailable arguments: outproc, count, broadcast, start, background, kill, help, attach\e[0m'
+		echo -e '\e[0;31mAvailable arguments: outproc, count, broadcast, start, background, kill, killback, help, attach\e[0m'
 		;;
 esac
 

--- a/commands.sh
+++ b/commands.sh
@@ -49,8 +49,32 @@ else
 	fi
 	case "$MESSAGE" in
 		'/question')
-			startproc "./question"
+			checkproc 
+			if [ $res -gt 0 ] ; then
+				startproc "./question"
+			else
+				send_normal_message "${CHAT[ID]}" "$MESSAGE already running ..."
+			fi
 			;;
+
+		'/run-notify') 
+			myback="notify"; checkback "$myback"
+			if [ $res -gt 0 ] ; then
+				background "./notify 60" "$myback" # notify every 60 seconds
+			else
+				send_normal_message "${CHAT[ID]}" "Background command $myback already running ..."
+			fi
+			;;
+		'/stop-notify')
+			myback="notify"; checkback "$myback"
+			if [ $res -eq 0 ] ; then
+				killback "$myback"
+				send_normal_message "${CHAT[ID]}" "Background command $myback canceled."
+			else
+				send_normal_message "${CHAT[ID]}" "No background command $myback is currently running.."
+			fi
+			;;
+
 		'/info')
 			send_markdown_message "${CHAT[ID]}" "This is bashbot, the *Telegram* bot written entirely in *bash*."
 			;;
@@ -82,7 +106,8 @@ Get the code in my [GitHub](http://github.com/topkecleon/telegram-bot-bash)
      			;;
      			
 		'/cancel')
-			if tmux ls | grep -q $copname; then killproc && send_message "${CHAT[ID]}" "Command canceled.";else send_message "${CHAT[ID]}" "No command is currently running.";fi
+			checkprog
+			if [ $res -eq 0 ] ; then killproc && send_message "${CHAT[ID]}" "Command canceled.";else send_message "${CHAT[ID]}" "No command is currently running.";fi
 			;;
 		*)
 			if tmux ls | grep -v send | grep -q $copname;then inproc; else send_message "${CHAT[ID]}" "$MESSAGE" "safe";fi

--- a/notify
+++ b/notify
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This file is public domain in the USA and all free countries.
+# Elsewhere, consider it to be WTFPLv2. (wtfpl.net/txt/copying)
+
+# check if $1 is a number
+re='^[0-9]+$'
+if [[ $1 =~ $re ]] ; then
+	SLEEP="$1"
+else
+	SLEEP=10 # time between time notifications
+fi
+
+# output current time every $1 seconds
+while sleep $SLEEP
+do
+	date "+* It's %k:%M:%S o' clock ..."
+done
+


### PR DESCRIPTION
Hi,

I really like your bot and use it for our telegram channels. I started using 'startproc' to post messages triggred by external events. this was so successful that our members asked me about the ability to run multiple jobs in background.

As 'startproc' is designed for single interactive chats, I added the ablity to run multiple scripts. Since only one script should be an interactive script I called it 'background jobs'. background jobs are internally handled by start/killproc but has are prefixed by 'back-jobname-'. e.g. tmux ls shows on my box:

```
back-report-dealz-Deal_O_Mat_bot_-1001189446635: 1 windows (created Mon Mar 18 19:54:01 2019) [80x24]
back-report-dealz-Deal_O_Mat_bot_336498079: 1 windows (created Mon Mar 18 19:54:01 2019) [80x24]
sendprocess_back-report-dealz-Deal_O_Mat_bot_-1001189446635: 1 windows (created Mon Mar 18 19:54:01 2019) [80x24]
sendprocess_back-report-dealz-Deal_O_Mat_bot_336498079: 1 windows (created Mon Mar 18 19:54:01 2019) [80x24]
```

In addtion its possible to restart running background jobs from commandline, e.g. after a reboot:
```
./bashbot.sh background 
```
This is possible because while starting a background job a .cmd file is written, containing the information needed to restart the job:  'CHAT[ID]:jobname:./command'.

So what I've done?
1. location of temp files (fifo) is now configurable and by default in './tmp-bot-bash'
2. startproc/killproc accepts a jobname as second argument used as prefix for fifo and tmux names
without jobname they work as before
3. background/killback make use of the second argument to create multiple jobs prefixed by 'back-jobname' and handle the .cmd file to restart background jobs:
```
ll tmp-bot-bash
prw-r--r-- 1 root root  0 18. Mar 20:00 back-report-dealz-Deal_O_Mat_bot_-1001189446635
prw-r--r-- 1 root root  0 18. Mar 20:00 back-report-dealz-Deal_O_Mat_bot_336498079
-rw-r--r-- 1 root root 46 18. Mar 18:04 Deal_O_Mat_bot_-1001189446635report-dealz-back.cmd
-rw-r--r-- 1 root root 41 18. Mar 18:19 Deal_O_Mat_bot_336498079report-dealz-back.cmd

```
4. checkproc/checkback functions make it easyer for programmers to check if an interactive command or a background job is running. I updated commands.sh to use them:
```
  '/question')
             checkproc
             if [ $res -gt 0 ] ; then
                    startproc "./question"
             else
                   send_normal_message "${CHAT[ID]}" "$MESSAGE already running ..."
             fi
             ;;
```
5. implement command line option 'background' to restart active background jobs and 'killback' to remove all running background jobs. First I used the existing start/killproc functions, but decided code it seperated to be more failsave.

```
   "background")
           clear
           echo -e '\e[0;32mRestart background processes ...\e[0m'
           for FILE in ${TMPDIR}/*-back.cmd; do
               if [ "$FILE" == "${TMPDIR}/*-back.cmd" ]; then
                   echo -e '\e[0;31mNo background processes to start.\e[0m'; break
               else
                   RESTART="$(cat "$FILE")"
                   CHAT[ID]="${RESTART%%:*}"
                   JOB="${RESTART#*:}"
                   PROG="${JOB#*:}"
                   JOB="${JOB%:*}"
                   fifo="back-${JOB}-${ME}_${CHAT[ID]}" # compose fifo from jobname, $ME (botname) and CHAT[ID]
                   echo "restartbackground  ${PROG}  ${fifo}"
                   ( tmux kill-session -t "${fifo}"; tmux kill-session -t sendprocess_${fifo}; rm -r $TMPDIR/${fifo}) 2>/dev/null
                   mkfifo "$TMPDIR/${fifo}"
                   TMUX= tmux new-session -d -s "${fifo}" "${PROG} &>$TMPDIR/${fifo}; echo imprettydarnsuredatdisisdaendofdacmd>$TMPDIR/${fifo}"
                   TMUX= tmux new-session -d -s sendprocess_${fifo} "bash $SCRIPT outproc ${CHAT[ID]} ${fifo}"
               fi
           done
           ;;

```` 

I've tested this on my private chats and it's running with up to five background jobs in our telegram channels. Nevertheless there are two possible issues:

1. since background jobs use the startproc logic the scripts will also get user input but should not process them.  this may lead to problems if STDIN pipe of the script gets filled. For now I had no problems with this.
2. startproc function has an possible incompatibility with exsiting callers because of the second argument. if someone has called startproc with multiple arguments it was working in the past, even it was wrong:
```
startproc "./script" "scriptarg1" ... "scripttargN"
```
Now it will start './script' with 'scriptarg1' as prefix and ignore all remaining arguments. 
this callers must be changed. IMHO the correct usage was and is:
```
startproc "./script scriptarg1 ... scripttargN"
```

Hope you like it :-)